### PR TITLE
Shorten code using decorators, correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,19 @@ To install `basencode`, run `python3 -m pip install basencode`. Now you should b
 Integer(66666)
 >>> myint2 - myint1
 Integer(41976)
->>>
 >>> myint1 * myint2
 Integer(670592745)
 >>> myint2 / myint1
-Integer(4)
+4.400243013365735
 >>> myint2 // myint1
 Integer(4)
 >>> myint2 % myint1
 Integer(4941)
 >>> divmod(myint2, myint1)
 (Integer(4), Integer(4941))
-
 ```
 
 ## TODO
-* Support operations between `int` and `Integer`
 * Add support for `float`s
 * Retain all default digits during arithmetic operations
 

--- a/basencode/__init__.py
+++ b/basencode/__init__.py
@@ -1,5 +1,5 @@
+from string import ascii_lowercase, ascii_uppercase, digits
 from typing import Dict, List, Union
-from string import digits, ascii_lowercase, ascii_uppercase
 
 __author__ = 'pranav.pooruli@gmail.com'
 __name__ = 'basencode'
@@ -9,6 +9,22 @@ BASE_DIGITS: Dict[int, List[str]] = {1: ['0']}
 
 for i in range(2, 65):
     BASE_DIGITS[i] = BASE_DIGITS[i - 1] + [ALL_CHARACTERS[i - 1]]
+
+
+def get_int_func(func_name):
+    int_func = getattr(int, func_name)
+
+    def convert_from_int_and_call(self, other):
+        if isinstance(other, int):
+            val = int_func(self.dec_value, other)
+        else:
+            val = int_func(self.dec_value, other.dec_value)
+        # Return an Integer if it's an int
+        # We don't use `isinstance` as bools are considered ints in Python
+        if type(val) == int:
+            return Integer(val)
+        return val
+    return convert_from_int_and_call
 
 
 class Integer:
@@ -63,21 +79,6 @@ class Integer:
         new_digits += digits_[0] * place
         return new_digits
 
-    def to_dec(self) -> int:
-        return self.dec_value
-
-    def to_bin(self) -> str:
-        return self.to_base(2)
-
-    def to_octal(self) -> str:
-        return self.to_base(8)
-
-    def to_hex(self) -> str:
-        return self.to_base(16)
-
-    def to_base64(self) -> str:
-        return self.to_base(64)
-
     def get_digits(self, base: int, digits: List[str]) -> List[str]:
         digits_: List[str]
         if not digits:
@@ -99,29 +100,29 @@ class Integer:
         dupl_add = dupl.add
         return [x for x in l if not (x in dupl or dupl_add(x))]
 
-    def __eq__(self, other):
-        return self.dec_value == other.dec_value
-
     def __repr__(self):
         return f'Integer({self.dec_value})'
 
-    def __add__(self, other):
-        return Integer(self.dec_value + other.dec_value)
+    def to_dec(self) -> int:
+        return self.dec_value
 
-    def __sub__(self, other):
-        return Integer(self.dec_value - other.dec_value)
+    def to_bin(self) -> str:
+        return self.to_base(2)
 
-    def __mul__(self, other):
-        return Integer(self.dec_value * other.dec_value)
+    def to_octal(self) -> str:
+        return self.to_base(8)
 
-    def __truediv__(self, other):
-        return Integer(self.dec_value // other.dec_value)
+    def to_hex(self) -> str:
+        return self.to_base(16)
 
-    def __floordiv__(self, other):
-        return self / other
+    def to_base64(self) -> str:
+        return self.to_base(64)
 
-    def __mod__(self, other):
-        return Integer(self.dec_value % other.dec_value)
-
-    def __divmod__(self, other):
-        return tuple(Integer(val) for val in divmod(self.dec_value, other.dec_value))
+    __eq__ = get_int_func("__eq__")
+    __add__ = get_int_func("__add__")
+    __sub__ = get_int_func("__sub__")
+    __mul__ = get_int_func("__mul__")
+    __truediv__ = get_int_func("__truediv__")
+    __floordiv__ = get_int_func("__floordiv__")
+    __mod__ = get_int_func("__mod__")
+    __divmod__ = get_int_func("__divmod__")

--- a/basencode/__init__.py
+++ b/basencode/__init__.py
@@ -14,16 +14,17 @@ for i in range(2, 65):
 def get_int_func(func_name):
     int_func = getattr(int, func_name)
 
+
     def convert_from_int_and_call(self, other):
         if isinstance(other, int):
             val = int_func(self.dec_value, other)
         else:
             val = int_func(self.dec_value, other.dec_value)
-        # Return an Integer if it's an int
-        # We don't use `isinstance` as bools are considered ints in Python
         if type(val) == int:
             return Integer(val)
         return val
+
+
     return convert_from_int_and_call
 
 
@@ -118,11 +119,11 @@ class Integer:
     def to_base64(self) -> str:
         return self.to_base(64)
 
-    __eq__ = get_int_func("__eq__")
-    __add__ = get_int_func("__add__")
-    __sub__ = get_int_func("__sub__")
-    __mul__ = get_int_func("__mul__")
-    __truediv__ = get_int_func("__truediv__")
-    __floordiv__ = get_int_func("__floordiv__")
-    __mod__ = get_int_func("__mod__")
-    __divmod__ = get_int_func("__divmod__")
+    __eq__ = get_int_func('__eq__')
+    __add__ = get_int_func('__add__')
+    __sub__ = get_int_func('__sub__')
+    __mul__ = get_int_func('__mul__')
+    __truediv__ = get_int_func('__truediv__')
+    __floordiv__ = get_int_func('__floordiv__')
+    __mod__ = get_int_func('__mod__')
+    __divmod__ = get_int_func('__divmod__')


### PR DESCRIPTION
Hi,
I've used decorators to shorten the code inside the class and simultaneously add support for integers - we could also easily add support for other built-in integer functions now. Apart from that, I've rearranged the code inside the basencode library a little bit.

In the README, I've corrected a line - in your README, floor division and true division returned the same product - even though this is wrong by the code. In the code too, you've used code meant for floor division in true division, and vice versa. In this commit, the problem gets solved automatically as we're using built-in `int` functions to implement all `Integer` functionality.

All class functions return a value of type `Integer`, except Boolean functions like `__eq__` and true division (returns a float, we could make it type `Integer` after we've added support for floats.

The README needs to be updated to reflect that calculations can now be done with integers, e.g. `myint1 * 2` will return 24690.

Thanks, and please do test before committing!